### PR TITLE
Create prompt_templates.ipynb

### DIFF
--- a/Master Generative AI/prompt_templates.ipynb
+++ b/Master Generative AI/prompt_templates.ipynb
@@ -1,0 +1,311 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from dotenv import load_dotenv, find_dotenv\n",
+    "_ = load_dotenv(find_dotenv())\n",
+    "openai_api_key = os.environ[\"OPENAI_API_KEY\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Completion Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import OpenAI\n",
+    "llmModel = OpenAI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import PromptTemplate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Once, a famous Bollywood actor was shooting a scene where he had to do a dramatic monologue. However, during the take, a stray dog ran onto the set and started barking loudly. The actor, not wanting to disrupt the scene, continued with his monologue and improvised by incorporating the dog into it. The crew and other actors were struggling to contain their laughter as the dog seemed to understand the actor's emotions and started howling along with him. The director loved the unexpected twist and decided to keep it in the final cut, making the scene even more dramatic and hilarious at the same time. From then on, the dog became the unofficial mascot of the film and even appeared in a few more scenes, stealing the show every time. The actor, who was initially irritated by the dog, ended up becoming best friends with him and they even went on to star in a few more movies together.\n"
+     ]
+    }
+   ],
+   "source": [
+    "prompt_template = PromptTemplate.from_template(\n",
+    "    \"Tell me a {adjective} story about {topic}\"\n",
+    ")\n",
+    "\n",
+    "llmModelPrompt = prompt_template.format(\n",
+    "    adjective=\"funny\",\n",
+    "    topic=\"bollywood\"\n",
+    ")\n",
+    "\n",
+    "res = llmModel.invoke(llmModelPrompt)\n",
+    "print(res)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Chat Completion Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "chatModel = ChatOpenAI(model=\"gpt-3.5-turbo-0125\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "from langchain_core.prompts import ChatPromptTemplate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chat_template = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\"system\", \"You are an {profession} expert on {topic}.\"),\n",
+    "        (\"human\", \"Hello, Mr. {profession}, can you please answer a question?\"),\n",
+    "        (\"ai\", \"Sure!\"),\n",
+    "        (\"human\", \"{user_input}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "\n",
+    "messages = chat_template.format_messages(\n",
+    "    profession=\"director do a moview\",\n",
+    "    topic=\"funny movie \",\n",
+    "    user_input=\"give some name of funny bollywood movie\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certainly! Here are some popular funny Bollywood movies:\n",
+      "\n",
+      "1. \"Hera Pheri\"\n",
+      "2. \"Andaz Apna Apna\"\n",
+      "3. \"Golmaal: Fun Unlimited\"\n",
+      "4. \"Chupke Chupke\"\n",
+      "5. \"Hungama\"\n",
+      "6. \"Welcome\"\n",
+      "7. \"Dhol\"\n",
+      "8. \"Dhamaal\"\n",
+      "9. \"Phir Hera Pheri\"\n",
+      "10. \"3 Idiots\"\n",
+      "\n",
+      "These movies are known for their comedy and are sure to make you laugh out loud!\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "response = chatModel.invoke(messages)\n",
+    "print(response.content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "## Prompts and Prompt Templates\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Few Shot Prompting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import FewShotChatMessagePromptTemplate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "examples = [\n",
+    "    {\"input\": \"hi!\", \"output\": \"Â¡hola!\"},\n",
+    "    {\"input\": \"bye!\", \"output\": \"Â¡adiÃ³s!\"},\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\"human\", \"{input}\"),\n",
+    "        (\"ai\", \"{output}\"),\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "few_shot_prompt = FewShotChatMessagePromptTemplate(\n",
+    "    example_prompt=example_prompt,\n",
+    "    examples=examples,\n",
+    ")\n",
+    "\n",
+    "final_prompt = ChatPromptTemplate.from_messages(\n",
+    "    [\n",
+    "        (\"system\", \"You are an English-Spanish translator.\"),\n",
+    "        few_shot_prompt,\n",
+    "        (\"human\", \"{input}\"),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "input_text = \"Translate 'I am learning programming'\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "AI: Estoy aprendiendo programaciÃ³n.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = chatModel.invoke(final_prompt.format(input=input_text))\n",
+    "print(response.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lang",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This pull request introduces a new Jupyter Notebook file `prompt_templates.ipynb` that demonstrates the usage of various prompt templates with the OpenAI API and LangChain library. The notebook includes code examples for completion models, chat completion models, and few-shot prompting.

Key changes include:

### Completion Model:

* Added code to load the OpenAI API key from environment variables and initialize the `OpenAI` model.
* Created a `PromptTemplate` for generating a story and demonstrated its usage with the `OpenAI` model.

### Chat Completion Model:

* Added initialization of the `ChatOpenAI` model with a specific version (`gpt-3.5-turbo-0125`).
* Created a `ChatPromptTemplate` with predefined messages and demonstrated its usage with the `ChatOpenAI` model.

### Few Shot Prompting:

* Introduced a `FewShotChatMessagePromptTemplate` with example messages and demonstrated its usage for translation tasks.